### PR TITLE
neaten tests for success

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,11 +2,13 @@ use inc::Module::Install;
 name 'Test-FTP-Server';
 all_from 'lib/Test/FTP/Server.pm';
 
+perl_version '5.006001';
 requires 'Net::FTPServer';
 
 tests 't/*.t';
 author_tests 'xt';
 
+test_requires 'Net::FTP';
 test_requires 'Test::More' => '0.88';
 test_requires 'Test::TCP';
 test_requires 'File::Copy::Recursive';

--- a/t/02_root.t
+++ b/t/02_root.t
@@ -45,7 +45,7 @@ test_tcp(
 	client => sub {
 		my $port = shift;
 
-		my $ftp = Net::FTP->new('localhost', Port => $port);
+		my $ftp = Net::FTP->new('127.0.0.1', Port => $port);
 		ok($ftp);
 		ok($ftp->login($user, $pass));
 		is(

--- a/t/03_sandbox.t
+++ b/t/03_sandbox.t
@@ -40,7 +40,7 @@ test_tcp(
 	client => sub {
 		my $port = shift;
 
-		my $ftp = Net::FTP->new('localhost', Port => $port);
+		my $ftp = Net::FTP->new('127.0.0.1', Port => $port);
 		ok($ftp);
 		ok($ftp->login($user, $pass));
 		is(

--- a/t/99_dependencies.t
+++ b/t/99_dependencies.t
@@ -1,6 +1,26 @@
-use ExtUtils::MakeMaker;
-use Test::Dependencies
-exclude => [qw(
+use strict;
+use warnings;
+
+use strict;
+use warnings;
+use Test::More;
+
+SKIP: {
+    skip 'CPAN::Meta not installed', 1
+	unless eval 'require CPAN::Meta; 1';
+    skip 'File::Find::Rule::Perl not installed', 1
+	unless eval 'require File::Find::Rule::Perl; 1';
+    skip 'Test::Dependencies not installed', 1 
+	unless eval 'require Test::Dependencies; 1';
+
+    Test::Dependencies->import(exclude => [qw{ExtUtils::MakeMaker}],
+			       style => 'light');
+
+    my $meta = CPAN::Meta->load_file('MYMETA.yml');
+    my @files =
+	File::Find::Rule::Perl->perl_file->in('./lib', './t');
+
+    ok_dependencies($meta, \@files, ignores => [qw(
 	Test::Dependencies Test::Perl::Critic
 
 	Test::FTP::Server
@@ -13,8 +33,9 @@ exclude => [qw(
 	Net::FTPServer::Full::DirHandle
 	Net::FTPServer::Full::Server
 
-
 	Test::TCP
 	File::Copy::Recursive
-)], style   => 'light';
-ok_dependencies();
+        )]);
+};
+
+done_testing();


### PR DESCRIPTION
A few tests were failing for me and these changes change that.

```
t/02_root.t .......... 1/? 
#   Failed test at t/02_root.t line 51.
#          got: ''
#     expected: 'testdir'
Can't use an undefined value as an ARRAY reference at t/02_root.t line 60.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 10 just after 4.
t/02_root.t .......... Dubious, test returned 10 (wstat 2560, 0xa00)
Failed 1/4 subtests 
t/03_sandbox.t ....... 1/? 
#   Failed test at t/03_sandbox.t line 46.
#          got: ''
#     expected: 'testdir'
Can't use an undefined value as an ARRAY reference at t/03_sandbox.t line 55.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 10 just after 4.
```